### PR TITLE
Update requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 Akka example and homework code for the "Big Data Systems" lecture.
 
 ## Requirements
-- Java 9 >=
-- Maven Compiler Version 3.1.8 >=
+- Java >= 9, <= 17
+- Maven Compiler Version >= 3.8.1
 
 ## Getting started
 1. Clone repo


### PR DESCRIPTION
- fixes typo in maven compiler version
- restricts Java version to be 17 at most, Maven cannot compile with a newer Java version:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project ddm-akka: Compilation failure
[ERROR] [options] system modules path not set in conjunction with -source 9
```